### PR TITLE
Fix gcc/clang compile warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,34 @@ project(
   DESCRIPTION "xwiimote-ng library")
 
 include(GNUInstallDirs)
+include(CheckSymbolExists)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/modules")
+
+# Subobject initialisation requires C99
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# asprintf must be included via _GNU_SOURCE
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+check_symbol_exists(asprintf stdio.h HAVE_ASPRINTF)
+if (NOT HAVE_ASPRINTF)
+    message(
+        FATAL_ERROR("xwiimote requires asprintf")
+    )
+endif()
+unset(CMAKE_REQUIRED_DEFINITIONS)
+add_definitions(-D_GNU_SOURCE)
+
+
+# Array iface_to_if_table uses a gnu extension range initializer with overrides.
+set(CMAKE_C_EXTENSIONS ON)
+# Fix compiler specific initialiser warnings
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-override-init")
+elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-initializer-overrides -Wno-gnu-designator")
+endif()
 
 find_package(UDev REQUIRED)
 
@@ -21,7 +47,7 @@ set_target_properties(xwiimote-ng PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(xwiimote-ng PROPERTIES SOVERSION 3)
 set_target_properties(xwiimote-ng PROPERTIES PUBLIC_HEADER lib/xwiimote-ng.h)
 
-if (BUILD_XWIIDUMB)
+if (BUILD_XWIIDUMP)
     add_executable(xwiidump-ng tools/xwiidump.c)
     install(TARGETS xwiidump-ng)
 endif()

--- a/lib/core.c
+++ b/lib/core.c
@@ -811,8 +811,8 @@ static int read_umon(struct xwii_iface *dev, struct epoll_event *ep, struct xwii
 			npath = udev_device_get_syspath(ndev);
 			node = udev_device_get_devnode(ndev);
 			p = udev_device_get_parent_with_subsystem_devtype(ndev, "hid", NULL);
-			if (p)
-				ppath = udev_device_get_syspath(p);
+			/* udev_device_get_syspath returns null if p is null */
+			ppath = udev_device_get_syspath(p);
 
 			if (act && !strcmp(act, "change") && !strcmp(path, npath))
 				hotplug = true;
@@ -1750,7 +1750,7 @@ int xwii_iface_dispatch(struct xwii_iface *dev, struct xwii_event *u_ev, size_t 
 	ret = epoll_wait(dev->efd, ep, siz, 0);
 	if (ret < 0)
 		return -errno;
-	if (ret > siz)
+	if ((unsigned) ret > siz)
 		ret = siz;
 
 	for (i = 0; i < ret; ++i) {

--- a/tools/xwiishow.c
+++ b/tools/xwiishow.c
@@ -1540,7 +1540,7 @@ static void classic_show_ext(const struct xwii_event *event)
 	if (event->type == XWII_EVENT_CLASSIC_CONTROLLER_KEY) {
 		ev = *event;
 		ev.type = XWII_EVENT_PRO_CONTROLLER_KEY;
-		return pro_show_ext(&ev);
+		pro_show_ext(&ev);
 	}
 
 	/* forward axis events to pro handler... */
@@ -2603,7 +2603,7 @@ static int run_iface(struct xwii_iface *iface)
 	return ret;
 }
 
-static int enumerate()
+static int enumerate(void)
 {
 	struct xwii_monitor *mon;
 	char *ent;


### PR DESCRIPTION
While packaging this for `plasma-bigscreen`, I noticed that `asprintf` is undefined on `glibc`.
That's because the symbol is hidden behind `_GNU_SOURCE`, although on most libcs it is exposed directly. This will mostly work in general, as the ansi C default prototype returns `int32` and `asprintf` returns an `int`. 
I didn't check all libcs, specifically not `bionic`, `dietlibc` and most of the proprietary Unixes. Portability may require some more work here.

While I was at it, I fixed most other compile warnings:
 - the initializer of `iface_to_if_table[]` is a gnu extension with overrides.
   I've added `gnu99` as a dialect and muted warnings about overrides. The proper fix would be to convert this into a switch statement, but I like its elegance. Unfortunately gcc will warn about gnu extensions with `pedantic` even if the dialect is set to gnu, so people who use `Werror` and `pedantic` are out of luck.
 - `ppath` gets defined in a branch. Since `udev_device_get_syspath` returns `NULL` if `p` is null, I simply removed the branch
 - `void classic_show_ext()` has a return in a void. Removed that.
 -  changed `static int enumerate(void)` to an ansi prototype
 - comparison of `(ret > siz)` compares signed to unsigned. Since `ret` is already known to be positive, we can simply cast to unsigned.

Fixed a typo, `XWIIDUMB`. Unless you really meant the tool is dumb, then mea culpa.

Finally, there's one portability issue I did not fix. The proper `posix` prototype to `ioctl` is `int ioctl(int, int, ...)`. Most modern Unixes do not heed this, but `musl` is posixly correct, so compiling on musl will emit a warning. I think this is not a problem this package ought to address.